### PR TITLE
Drop dependency on PureMD5

### DIFF
--- a/cabal2arch.cabal
+++ b/cabal2arch.cabal
@@ -23,7 +23,6 @@ executable cabal2arch
         containers,
         bytestring,
         Cabal   > 1.8,
-        pureMD5 >= 0.2.1,
         filepath,
         archlinux > 0.1
 


### PR DESCRIPTION
PureMD5 is Haskell implementation of MD5 which unfortunately depends on many other modules: replacing puremd5 usage by a call to "makepkg -g" has the advantage of:
- making cabal2arch buildable with only GHC and archlinux module installed
- using a local copy of the source package if it is in makepkg cache.
