### PR TITLE
Add configure flags to generated PKGBUILD

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -124,10 +124,8 @@ subCmd (CmdLnConvertOne cabalLoc createTar dataFiles) =
                 Left s -> die s
                 Right sp -> return sp
             let finalcabal = preprocessCabal cabalsrc [] sysProvides
-            finalcabal' <- case finalcabal of
-                Nothing -> die "Aborting..."
-                Just (f, _) -> return f
-            let (pkgbuild', hooks) = cabal2pkg finalcabal' sysProvides
+            (finalcabal', cblflags) <- maybe (die "Aborting...") (\ f -> return (f)) finalcabal
+            let (pkgbuild', hooks) = cabal2pkg finalcabal' cblflags sysProvides
 
             apkgbuild' <- getMD5 pkgbuild'
             let apkgbuild = apkgbuild' { pkgBuiltWith = Just version }
@@ -196,8 +194,8 @@ exportPackage dot email sysProvides p = do
     let q = preprocessCabal p [] sysProvides
     case q of
         Nothing -> return ()
-        Just (p', _) -> do
-            let (pkg, script) = cabal2pkg p' sysProvides
+        Just (p', f) -> do
+            let (pkg, script) = cabal2pkg p' f sysProvides
                 pkgname = arch_pkgname (pkgBody pkg)
             pkgbuild  <- getMD5 pkg
             let apkgbuild = pkgbuild { pkgBuiltWith = Just version }

--- a/Main.hs
+++ b/Main.hs
@@ -123,10 +123,10 @@ subCmd (CmdLnConvertOne cabalLoc createTar dataFiles) =
             sysProvides <- case maybeSysProvides of
                 Left s -> die s
                 Right sp -> return sp
-            let finalcabal = preprocessCabal cabalsrc sysProvides
+            let finalcabal = preprocessCabal cabalsrc [] sysProvides
             finalcabal' <- case finalcabal of
                 Nothing -> die "Aborting..."
-                Just f -> return f
+                Just (f, _) -> return f
             let (pkgbuild', hooks) = cabal2pkg finalcabal' sysProvides
 
             apkgbuild' <- getMD5 pkgbuild'
@@ -193,10 +193,10 @@ subCmd (CmdLnConvertMany pkgListLoc tarballLoc repoLoc dataFiles) = do
 
 exportPackage :: FilePath -> String -> SystemProvides -> GenericPackageDescription -> IO ()
 exportPackage dot email sysProvides p = do
-    let q = preprocessCabal p sysProvides
+    let q = preprocessCabal p [] sysProvides
     case q of
         Nothing -> return ()
-        Just p' -> do
+        Just (p', _) -> do
             let (pkg, script) = cabal2pkg p' sysProvides
                 pkgname = arch_pkgname (pkgBody pkg)
             pkgbuild  <- getMD5 pkg

--- a/cabal2arch.cabal
+++ b/cabal2arch.cabal
@@ -1,5 +1,5 @@
 name:               cabal2arch
-version:            0.7.7
+version:            0.8
 homepage:           http://github.com/archhaskell/
 synopsis:           Create Arch Linux packages from Cabal packages.
 description:        Create Arch Linux packages from Cabal packages.
@@ -30,7 +30,7 @@ executable cabal2arch
         Cabal > 1.8,
         filepath,
         mtl,
-        archlinux >= 0.3.6,
+        archlinux ==0.4.*,
         cmdargs
 
     other-modules:


### PR DESCRIPTION
These changes makes sure `cabal2arch` uses the modified API of `archlinux` (see the related pull request archhaskell/archlinux#6).  They also add a new command line flag so configure flags can be passed in at the call (only when converting one Cabal file though).

I thought this would warrant a pull request since it modifies the output.
